### PR TITLE
Fix gauge indicator showing up in wrong place

### DIFF
--- a/src/components/gauge/index.js
+++ b/src/components/gauge/index.js
@@ -51,7 +51,7 @@ export default (props) => {
         preserveAspectRatio="xMidYMid meet"
         width="10%"
         height="30%"
-        x={calcAxisPos(props.value)}
+        x={calcAxisPos(props.value) + "%"}
       >
         <g fill="white">
           <text 
@@ -60,7 +60,6 @@ export default (props) => {
             textAnchor="middle"
             x="0"
             y="0"
-            // fontSize="1em"
           >
             {props.value}
           </text>


### PR DESCRIPTION
It needed to have % appended to the position.

Before:
![Screenshot_20200604_165416](https://user-images.githubusercontent.com/2229184/83818321-529aec00-a684-11ea-8904-ba3a70fb7f02.png)
After:
![Screenshot_20200604_165441](https://user-images.githubusercontent.com/2229184/83818326-57f83680-a684-11ea-90b7-219eeb81d04e.png)
