### PR TITLE
Fix CO₂ Prediciton and Carbon Gauge

### DIFF
--- a/src/components/5-year-cost/index.js
+++ b/src/components/5-year-cost/index.js
@@ -3,7 +3,7 @@ import { useParams } from 'react-router';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { breakdownTransition } from '../../hooks/pageTransitions';
-import { fetchPredictionPrice } from '../../hooks/dataFetching';
+import { fetchPrediction } from '../../hooks/dataFetching';
 
 import PrevPage from '../../hooks/prevPage';
 
@@ -20,7 +20,7 @@ const CostToOwn = () => {
     const [yearlyMaintenanceCost, setYearlyMaintenanceCost] = useState(0);
 
     useEffect(() => {
-        fetchPredictionPrice(id, (obj) => {
+        fetchPrediction(id, (obj) => {
             setTotalCost(Math.round(obj.five_year_cost_to_own));            
             setPurchasePrice(obj.predicted_price);
 

--- a/src/components/common/gauge/index.js
+++ b/src/components/common/gauge/index.js
@@ -15,6 +15,10 @@ export default (props) => {
     ...props,
   };
 
+  if (!props.text) {
+      props.text = "" + props.value;
+  }
+
   // Calculate the value as a percentage from 0 (min) to 100 (max)
   function calcAxisPos(val) {
     const percent = (100 * (val - props.min)) / (props.max - props.min);
@@ -61,7 +65,7 @@ export default (props) => {
             x="0"
             y="0"
           >
-            {props.value}
+            {props.text}
           </text>
           <polygon points="-10,5 0,25 10,5" />
         </g>

--- a/src/components/common/gauge/index.js
+++ b/src/components/common/gauge/index.js
@@ -56,6 +56,7 @@ export default (props) => {
         width="10%"
         height="30%"
         x={calcAxisPos(props.value) + "%"}
+        style={{overflow: "visible"}}
       >
         <g fill="white">
           <text 

--- a/src/components/compare-start/index.js
+++ b/src/components/compare-start/index.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router';
 import { motion } from 'framer-motion';
-import { fetchPredictionPrice } from '../../hooks/dataFetching';
+import { fetchPrediction } from '../../hooks/dataFetching';
 import { compareTransition } from '../../hooks/pageTransitions';
 
 import Breakdown from '../common/breakdown';
@@ -18,7 +18,7 @@ const CompareStart = () => {
     const [yearlyMaintenanceCost, setYearlyMaintenanceCost] = useState(0);
                                 
     useEffect(() => {
-        fetchPredictionPrice(id, (obj) => {
+        fetchPrediction(id, (obj) => {
             setTotalCost(Math.round(obj.five_year_cost_to_own));            
             setPurchasePrice(obj.predicted_price);
 

--- a/src/components/compare/index.js
+++ b/src/components/compare/index.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router';
 import { motion } from 'framer-motion';
-import { fetchPredictionPrice } from '../../hooks/dataFetching';
+import { fetchPrediction } from '../../hooks/dataFetching';
 import { compareAfterTransition } from '../../hooks/pageTransitions';
 
 import AddToCompare from '../common/buttons/addToCompare';
@@ -26,7 +26,7 @@ const Compare = () => {
     const [comparedYearlyMaintenanceCost, setComparedYearlyMaintenanceCost] = useState(0);
 
     useEffect(() => {
-        fetchPredictionPrice(id, (obj) => {
+        fetchPrediction(id, (obj) => {
             setMainCar(obj);
             setTotalCost(Math.round(obj.five_year_cost_to_own));            
             setPurchasePrice(obj.predicted_price);
@@ -38,7 +38,7 @@ const Compare = () => {
     }, [id]);
 
     useEffect(() => {
-        fetchPredictionPrice(carID, (obj) => {
+        fetchPrediction(carID, (obj) => {
             setComparedCar(obj);
             setComparedTotalCost(Math.round(obj.five_year_cost_to_own));            
             setComparedPurchasePrice(obj.predicted_price);

--- a/src/components/details/index.js
+++ b/src/components/details/index.js
@@ -46,7 +46,7 @@ const CarDetails = () => {
                 width={100} height={20}
                 min={0} max={MAX_CARBON_EMISSIONS}
                 value={predictedCarbonEmissions}
-                text={predictedCarbonEmissions.toLocaleString(undefined, {maximumFractionDigits:2})}/>
+                text={predictedCarbonEmissions.toLocaleString(undefined, {maximumFractionDigits:2}) + " kg"}/>
             <Divider className='divider' />             
             <h3>Cost of Ownership (5 years)</h3>
             <div>

--- a/src/components/details/index.js
+++ b/src/components/details/index.js
@@ -4,14 +4,14 @@ import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { Card, Divider } from "antd";
 import HorizontalGauge from '../common/gauge';
-import { fetchCarDetails, fetchPredictionCarbonEmissions, fetchPredictionPrice } from '../../hooks/dataFetching';
+import { fetchCarDetails, fetchPrediction } from '../../hooks/dataFetching';
 import CarDetailsStyles from './styles';
 
 import { detailsTransition } from '../../hooks/pageTransitions';
 import chevron from '../../assets/images/chevron.png';
 import CarGallery from '../common/image-gallery';
 
-const MAX_CARBON_EMISSIONS = 1400;
+const MAX_CARBON_EMISSIONS = 1400 * 100;
 
 const CarDetails = () => {
   const { id } = useParams();
@@ -23,10 +23,8 @@ const CarDetails = () => {
 
   useEffect(() => {
     fetchCarDetails(id, setCar)
-    fetchPredictionCarbonEmissions(id, (obj) => {
-      setPredictedCarbonEmissions(obj.predicted_carbon_emissions);
-    });
-    fetchPredictionPrice(id, (obj) => {
+    fetchPrediction(id, (obj) => {
+      setPredictedCarbonEmissions(obj.co2_five_year_kgs);
       setPredictedPrice(obj.five_year_cost_to_own.toLocaleString(undefined, {maximumFractionDigits: 2}));
       setCarImages(obj.list_of_imgs);
     });
@@ -47,7 +45,8 @@ const CarDetails = () => {
                 className='gauge'
                 width={100} height={20}
                 min={0} max={MAX_CARBON_EMISSIONS}
-                value={predictedCarbonEmissions.toLocaleString(undefined, {maximumFractionDigits:2})}/>
+                value={predictedCarbonEmissions}
+                text={predictedCarbonEmissions.toLocaleString(undefined, {maximumFractionDigits:2})}/>
             <Divider className='divider' />             
             <h3>Cost of Ownership (5 years)</h3>
             <div>

--- a/src/hooks/dataFetching.js
+++ b/src/hooks/dataFetching.js
@@ -76,20 +76,7 @@ export const fetchCarDetails = async (id, setCar) => {
 
 const API = "https://streetsmarts-labs24.herokuapp.com/api";
 
-export const fetchPredictionCarbonEmissions = async (id, setPredictionValue) => {
-  return await axios
-    .post(`${API}/predict/carbon_emissions/${id}`)
-    .then((res) => {
-      console.log(`This is response for fetchPredictionCarbonEmissions of ${id}`, res.data);
-      setPredictionValue(res.data);
-    })
-    .catch((err) => {
-      console.log(`Error fetching carbon emissions prediction for ${id}: ${err}`);
-      return err.message;
-    });
-};
-
-export const fetchPredictionPrice = async (id, setPredictionValue) => {
+export const fetchPrediction = async (id, setPredictionValue) => {
   return await axios
     .post(`${API}/predict/${id}`)
     .then((res) => {


### PR DESCRIPTION
Data science just got rid of the original carbon emissions endpoint. This pull request makes the code that uses the CO₂ prediction use the general prediction endpoint instead. It also fixes a bug where the carbon gauge indicator wasn't moving.